### PR TITLE
fix(faq): respond when no tags found

### DIFF
--- a/src/commands/faq.ts
+++ b/src/commands/faq.ts
@@ -24,7 +24,7 @@ export const faq: Command = {
       );
 
       if (!target) {
-        await interaction.reply(`No tag found for \`${targetName}\`.`);
+        await interaction.editReply(`No tag found for \`${targetName}\`.`);
         return;
       }
 


### PR DESCRIPTION
# Pull Request

<!--Before contributing, please read our contributing guidelines-->

## Description:

After defering an interaction reply, we cannot create another one, so we have to edit it. Which is why the bot was stuck defering if the tag is invalid.

## Related Issue:

Closes #415
