### PR TITLE
Add FAQ tag: PR/MR matures in November

### DIFF
--- a/src/data/tags.ts
+++ b/src/data/tags.ts
@@ -125,7 +125,7 @@ export const tags: Tag[] = [
   },
   {
     answer:
-      "Yes, your PR/MR will mature into November, even after October 31st! Don't worry about your PR/MR that's still awaiting review during the last week of October, the Hacktoberfest team had this in mind and allows your MR/PR to be potentially accepted and matured even though October has ended.",
-    question: "Will my PR/MR still be accepted, even if October is almost done?"
+      "As long as your PR/MR is approved, merged, or given the `hacktoberfest-accepted` label before October ends, it can be eligible for Hacktoberfest. The maturation period might extend into November, but that will not prevent your contribution from being counted.",
+    question: "Will my PR/MR still be eligible, even if October is almost done?"
   }
 ];

--- a/src/data/tags.ts
+++ b/src/data/tags.ts
@@ -126,6 +126,7 @@ export const tags: Tag[] = [
   {
     answer:
       "As long as your PR/MR is approved, merged, or given the `hacktoberfest-accepted` label before October ends, it can be eligible for Hacktoberfest. The maturation period might extend into November, but that will not prevent your contribution from being counted.",
-    question: "Will my PR/MR still be eligible, even if October is almost done?"
+    question:
+      "Will my PR/MR still be eligible, even if October is almost done?",
   }
 ];

--- a/src/data/tags.ts
+++ b/src/data/tags.ts
@@ -128,5 +128,5 @@ export const tags: Tag[] = [
       "As long as your PR/MR is approved, merged, or given the `hacktoberfest-accepted` label before October ends, it can be eligible for Hacktoberfest. The maturation period might extend into November, but that will not prevent your contribution from being counted.",
     question:
       "Will my PR/MR still be eligible, even if October is almost done?",
-  }
+  },
 ];

--- a/src/data/tags.ts
+++ b/src/data/tags.ts
@@ -123,4 +123,9 @@ export const tags: Tag[] = [
       "You have to opt-in via email for Holopin badges. If you opted in, make sure that the email did not land in your spam folder. Also, be sure that you opted in with the correct email address (not the GitHub no-reply email address). Finally, you should also see a `Claim Now` link in your Hacktoberfest profile.",
     question: "Why aren't my Holopin badges showing up?",
   },
+  {
+    answer:
+      "Yes, your PR/MR will mature into November, even after October 31st! Don't worry about your PR/MR that's still awaiting review during the last week of October, the Hacktoberfest team had this in mind and allows your MR/PR to be potentially accepted and matured even though October has ended.",
+    question: "Will my PR/MR still be accepted, even if October is almost done?"
+  }
 ];


### PR DESCRIPTION
# Pull Request

<!--Before contributing, please read our contributing guidelines-->

## Description:

Adds an FAQ tag that informs the user that his/her PR/MR will mature into November.

## Related Issue:
None