### PR TITLE
Handle Markdown and suppressed links

### DIFF
--- a/src/config/ProjectRegex.ts
+++ b/src/config/ProjectRegex.ts
@@ -1,4 +1,5 @@
-const boundary = "(?:^|$|[ \t\n])";
+const boundaryStart = "(?:^|[ \t\n<(])";
+const boundaryEnd = "(?:$|[ \t\n>)])";
 const protocol = "(?:https?:\\/\\/)?";
 const www = "(?:www\\.)?";
 // credit: https://github.com/shinnn/github-username-regex
@@ -11,6 +12,6 @@ const githubPath = `${githubUsername}\\/${repo}${optionalIssues}`;
 const gitlabPath = `${gitlabUsername}\\/${repo}${optionalIssues}`;
 
 export const ProjectRegex = new RegExp(
-  `${boundary}${protocol}${www}(?:github\\.com/${githubPath}|gitlab\\.com/${gitlabPath})${boundary}`,
+  `${boundaryStart}${protocol}${www}(?:github\\.com/${githubPath}|gitlab\\.com/${gitlabPath})${boundaryEnd}`,
   "mi"
 );

--- a/src/config/ProjectRegex.ts
+++ b/src/config/ProjectRegex.ts
@@ -1,5 +1,5 @@
 const boundaryStart = "(?:^|[ \t\n<(])";
-const boundaryEnd = "(?:$|[ \t\n>)])";
+const boundaryEnd = "(?:$|[ \t\n>),.])";
 const protocol = "(?:https?:\\/\\/)?";
 const www = "(?:www\\.)?";
 // credit: https://github.com/shinnn/github-username-regex

--- a/test/config/ProjectRegex.spec.ts
+++ b/test/config/ProjectRegex.spec.ts
@@ -59,6 +59,22 @@ suite("ProjectRegex", () => {
     )
   });
 
+  test("should match a link followed by a period", () => {
+    assert.isTrue(
+      ProjectRegex.test(
+        "Check out my repo: https://github.com/nhcarrigan/weLoveHacktoberfest. It is really cool."
+      )
+    )
+  });
+
+  test("should match a link followed by a comma", () => {
+    assert.isTrue(
+      ProjectRegex.test(
+        "You can contribute at https://github.com/nhcarrigan/weLoveHacktoberfest, it is really cool."
+      )
+    )
+  });
+
   test("should match a GitHub repository link", () => {
     assert.isTrue(
       ProjectRegex.test("https://github.com/nhcarrigan/weLoveHacktoberfest")

--- a/test/config/ProjectRegex.spec.ts
+++ b/test/config/ProjectRegex.spec.ts
@@ -35,6 +35,30 @@ suite("ProjectRegex", () => {
     );
   });
 
+  test("should match a suppressed link", () => {
+    assert.isTrue(
+      ProjectRegex.test(
+        "This repo <https://github.com/nhcarrigan/weLoveHacktoberfest> is really cool."
+      )
+    )
+  });
+
+  test("should match a Markdown link", () => {
+    assert.isTrue(
+      ProjectRegex.test(
+        "This [repo](https://github.com/nhcarrigan/weLoveHacktoberfest) is really cool."
+      )
+    )
+  });
+
+  test("should match a suppressed Markdown link", () => {
+    assert.isTrue(
+      ProjectRegex.test(
+        "This [repo](<https://github.com/nhcarrigan/weLoveHacktoberfest>) is really cool."
+      )
+    )
+  });
+
   test("should match a GitHub repository link", () => {
     assert.isTrue(
       ProjectRegex.test("https://github.com/nhcarrigan/weLoveHacktoberfest")


### PR DESCRIPTION
# Pull Request

## Description:

Adds support for links being wrapped in `()` or `<>`.

Also, allows links to be followed by a comma or period, for use in sentences.

## Related Issue:

Resolves #724
